### PR TITLE
Introduce SelectionPlugin and DebugSelectioInputPlugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +194,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6041616acea41d67c4a984709ddab1587fd0b10efe5cc563fee954d2f011854"
+dependencies = [
+ "clipboard-win",
+ "core-graphics",
+ "image",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "once_cell",
+ "parking_lot",
+ "thiserror",
+ "winapi",
+ "x11rb",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +273,12 @@ name = "atomic-arena"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5450eca8ce5abcfd5520727e975ebab30ccca96030550406b0ca718b224ead10"
+
+[[package]]
+name = "atomic_refcell"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "857253367827bd9d0fd973f0ef15506a96e79e41b0ad7aa691203a4e3214f6c8"
 
 [[package]]
 name = "autocfg"
@@ -481,6 +518,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_egui"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c40ec476443b97d5d9c6f40668da7ded2d83b13955a7c94c062ad2b6f98120"
+dependencies = [
+ "arboard",
+ "bevy",
+ "egui",
+ "thread_local",
+ "webbrowser",
+]
+
+[[package]]
 name = "bevy_encase_derive"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +706,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39106bc2ee21fce9496d2e15e0ba7925dff63e3eae10f7c1fc0094b56ad9f2bb"
 dependencies = [
  "glam",
+]
+
+[[package]]
+name = "bevy_mod_outline"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd68f243f1bf93317dc126ef3a7ffe0fb00ba8cd17306a726eeb0d92986edb66"
+dependencies = [
+ "bevy",
+ "bitfield",
+ "interpolation",
+ "thiserror",
 ]
 
 [[package]]
@@ -941,7 +1003,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a88ebbca55d360d72e9fe78df0d22e25cd419933c9559e79dae2757f7c4d066"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "bevy_utils_proc_macros",
  "getrandom 0.2.9",
  "hashbrown",
@@ -1038,6 +1100,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitfield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "bitflags"
@@ -1153,6 +1221,17 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
 ]
 
 [[package]]
@@ -1366,7 +1445,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
@@ -1427,6 +1506,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,10 +1538,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "ecolor"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f99fe3cac305af9d6d92971af60d0f7ea4d783201ef1673571567b6699964d9"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "egui"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6412a21e0bde7c0918f7fb44bbbb86b5e1f88e63c026a4e747cc7af02f76dfbe"
+dependencies = [
+ "ahash 0.8.3",
+ "epaint",
+ "nohash-hasher",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "emath"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ecd80612937e0267909d5351770fe150004e24dab93954f69ca62eecd3f77e"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "embed-resource"
@@ -1499,12 +1627,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "epaint"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e78b5c58a1f7f621f9d546add2adce20636422c9b251e29f749e8a2f713c95"
+dependencies = [
+ "ab_glyph",
+ "ahash 0.8.3",
+ "atomic_refcell",
+ "bytemuck",
+ "ecolor",
+ "emath",
+ "nohash-hasher",
+ "parking_lot",
+]
+
+[[package]]
 name = "erased-serde"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
 ]
 
 [[package]]
@@ -1581,6 +1735,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1786,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1831,7 +2004,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "serde",
 ]
 
@@ -1867,6 +2040,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "image"
 version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +2061,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "png",
+ "tiff",
 ]
 
 [[package]]
@@ -1927,6 +2111,12 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
+
+[[package]]
+name = "interpolation"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b7357d2bbc5ee92f8e899ab645233e43d21407573cceb37fed8bc3dede2c02"
 
 [[package]]
 name = "io-kit-sys"
@@ -1994,6 +2184,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,6 +2213,12 @@ checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
 
 [[package]]
 name = "js-sys"
@@ -2204,6 +2416,15 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
@@ -2340,6 +2561,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -2353,6 +2575,12 @@ dependencies = [
  "libc",
  "static_assertions",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noise"
@@ -2495,6 +2723,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
 name = "objc-sys"
 version = "0.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,6 +2766,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
 ]
 
 [[package]]
@@ -2951,6 +3199,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom 0.2.9",
+ "redox_syscall 0.2.16",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3196,6 +3455,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
 name = "svg_fmt"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3352,7 +3617,9 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy_atmosphere",
+ "bevy_egui",
  "bevy_kira_audio",
+ "bevy_mod_outline",
  "bevy_rapier3d",
  "colorgrad",
  "embed-resource",
@@ -3394,6 +3661,32 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
+
+[[package]]
+name = "tiff"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7449334f9ff2baf290d55d73983a7d6fa15e01198faef72af07e2a8db851e471"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -3517,10 +3810,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"
@@ -3533,6 +3841,17 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "urlencoding"
@@ -3704,6 +4023,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579cc485bd5ce5bfa0d738e4921dd0b956eca9800be1fd2e5257ebe95bc4617e"
+dependencies = [
+ "core-foundation",
+ "dirs",
+ "jni 0.21.1",
+ "log",
+ "ndk-context",
+ "objc",
+ "raw-window-handle",
+ "url",
+ "web-sys",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
 name = "wgpu"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,6 +4182,15 @@ name = "winapi-util"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-wsapoll"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
 dependencies = [
  "winapi",
 ]
@@ -4105,6 +4456,28 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592b4883219f345e712b3209c62654ebda0bb50887f330cbd018d0f654bfd507"
+dependencies = [
+ "gethostname",
+ "nix 0.24.3",
+ "winapi",
+ "winapi-wsapoll",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67"
+dependencies = [
+ "nix 0.24.3",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -51,6 +51,8 @@ default = [
 
 [dependencies]
 bevy = { version = "0.10.1", default-features = false }
+bevy_egui = "0.20"
+bevy_mod_outline = "0.4"
 bevy_rapier3d = { version = "0.21.0", default-features = false }
 leafwing-input-manager = "0.9.1"
 noise = "0.8.2"

--- a/lib/src/plugins/mod.rs
+++ b/lib/src/plugins/mod.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy_egui::EguiPlugin;
 
 pub mod animation;
 pub mod audio;
@@ -9,6 +10,7 @@ pub mod mouse_capture;
 pub mod movement;
 pub mod mushroom_generator;
 pub mod player;
+pub mod selection;
 pub mod sun;
 pub mod terrain;
 pub mod tree_generator;
@@ -22,6 +24,7 @@ pub use mouse_capture::*;
 pub use movement::*;
 pub use mushroom_generator::*;
 pub use player::*;
+pub use selection::*;
 pub use sun::*;
 pub use terrain::*;
 pub use tree_generator::*;
@@ -33,6 +36,7 @@ pub struct SideEffectsPlugin;
 impl Plugin for SideEffectsPlugin {
     fn build(&self, app: &mut App) {
         app.add_state::<GameState>()
+            .add_plugin(EguiPlugin)
             .add_plugin(AssetLoaderPlugin)
             .add_plugin(AnimationPlugin)
             .add_plugin(CameraPlugin)
@@ -42,6 +46,8 @@ impl Plugin for SideEffectsPlugin {
             .add_plugin(MainMenuPlugin)
             .add_plugin(MovementPlugin)
             .add_plugin(MushroomGeneratorPlugin)
+            .add_plugin(SelectionPlugin)
+            .add_plugin(DebugSelectionInputPlugin)
             .add_plugin(SunPlugin)
             .add_plugin(GameAudioPlugin)
             .add_system(debug_game_state_changes);

--- a/lib/src/plugins/mushroom_generator/system.rs
+++ b/lib/src/plugins/mushroom_generator/system.rs
@@ -1,6 +1,7 @@
 use super::component::*;
 use super::resource::*;
 use crate::components::player::Player;
+use crate::plugins::Selectable;
 use bevy::prelude::*;
 use bevy::utils::HashSet;
 use bevy_rapier3d::prelude::*;
@@ -110,6 +111,7 @@ pub fn spawn_mushroom(
                         1.5,
                         (3.0 * MUSHROOM_RENDER_SCALE).max(3.0),
                     ))
+                    .insert(Selectable)
                     .insert(Mushroom::default());
 
                 generate_count -= 1;

--- a/lib/src/plugins/selection.rs
+++ b/lib/src/plugins/selection.rs
@@ -1,0 +1,266 @@
+//! This module contains behavior related to the "selection" of [`Entity`] instances with the mouse,
+//! which is primarily intended to be used in selecting which "follower tanuki" are to be ordered to
+//! do a given task.
+//!
+//! # Interface
+//!
+//! [`Selectable`] -- A marker component designating an entity that may be selected. In order for
+//! selections to function as intended, possible selections must all have this component.
+//!
+//! [`Selected`] -- Another marker component which is intended to designate members of the active
+//! selection. This is managed automatically using the [`SelectionPlugin`].
+//!
+//! [`SelectionControlEvent`] -- An event type which must be emit in order to control the selection
+//! process.
+//!
+//! # How to use
+//!
+//!   1. Marke relevant entities to [`Selectable`]
+//!   2. Emit the desired [`SelectionControlEvent`]s based on player input
+//!   3. Query for [`Entity`] instances [`With`] the [`Selected`] component
+//!
+//! # Improvements
+//
+//!  * Box selection eg by dragging the GlobalTransform), With<MainCamera>>,
+
+use bevy::{prelude::*, scene::SceneInstance, utils::HashSet, window::PrimaryWindow};
+use bevy_egui::EguiContexts;
+use bevy_mod_outline::{
+    AutoGenerateOutlineNormalsPlugin, OutlineBundle, OutlinePlugin, OutlineVolume,
+};
+use bevy_rapier3d::prelude::*;
+
+use super::{camera::component::MainCamera, GameState};
+
+/// See the module docs for more information.
+pub struct SelectionPlugin;
+impl Plugin for SelectionPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(ActiveSelection(HashSet::new()))
+            .add_event::<SelectionControlEvent>()
+            .add_system(handle_selections.in_set(OnUpdate(GameState::InGame)));
+    }
+}
+
+pub struct DebugSelectionInputPlugin;
+impl Plugin for DebugSelectionInputPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugin(OutlinePlugin)
+            .add_plugin(AutoGenerateOutlineNormalsPlugin)
+            .add_system(debug_replace_extend_input.in_set(OnUpdate(GameState::InGame)))
+            .add_system(debug_highlight.in_set(OnUpdate(GameState::InGame)));
+    }
+}
+
+fn debug_replace_extend_input(
+    mut input_events: EventWriter<SelectionControlEvent>,
+    mouse: Res<Input<MouseButton>>,
+    keys: Res<Input<KeyCode>>,
+) {
+    if mouse.just_pressed(MouseButton::Left) {
+        if keys.pressed(KeyCode::LControl) || keys.pressed(KeyCode::RControl) {
+            input_events.send(SelectionControlEvent::ExtendSelectionWithHovered);
+        } else {
+            input_events.send(SelectionControlEvent::ReplaceSelectionWithHovered(true));
+        }
+    }
+}
+
+fn debug_highlight(
+    scene_query: Query<&SceneInstance>,
+    outline_query: Query<Entity, With<OutlineVolume>>,
+    scene_manager: Res<SceneSpawner>,
+    active_selection: Res<ActiveSelection>,
+    mut commands: Commands,
+) {
+    if active_selection.is_changed() {
+        for outlined in outline_query.iter() {
+            commands.entity(outlined).remove::<OutlineBundle>();
+        }
+
+        for sel in active_selection.0.iter() {
+            if let Ok(scene) = scene_query.get(*sel) {
+                for entity in scene_manager.iter_instance_entities(**scene) {
+                    commands.entity(entity).insert(OutlineBundle {
+                        outline: OutlineVolume {
+                            visible: true,
+                            width: 3.0,
+                            colour: Color::FUCHSIA,
+                        },
+                        ..Default::default()
+                    });
+                }
+            }
+
+            commands.entity(*sel).insert(OutlineBundle {
+                outline: OutlineVolume {
+                    visible: true,
+                    width: 3.0,
+                    colour: Color::FUCHSIA,
+                },
+                ..Default::default()
+            });
+        }
+    }
+}
+
+#[derive(Resource)]
+struct ActiveSelection(HashSet<Entity>);
+
+/// Whether to allow an [`Entity`] to be automatically be (un)assigned the [`Selected`] component
+/// upon the mouse hovering over that [`Entity`] and a relevant [`SelectionControlEvent`] being
+/// fired.
+#[derive(Component)]
+pub struct Selectable;
+
+/// Whether an [`Entity`] is in the active selection.
+///
+/// XXX: Please do not add or remove this copmonent manually. It is managed by the plugin's systems.
+/// If you need to assume "direct control", use [`SelectionControlEvent::DirectInsert`] event or its
+/// counterpart [`SelectionControlEvent::DirectRemove`].
+#[derive(Component)]
+pub struct Selected;
+
+/// The events used to control the [`SelectionPlugin`]. Meant to be a thin mapping from user input
+/// to the control options, such as to allow any control scheme.
+pub enum SelectionControlEvent {
+    /// Remove [`Selected`] from all [`Entity`] instances that currently have it
+    ClearSelection,
+
+    /// Remove [`Selected`] from all [`Entity`] instances that currently have it, then adding the
+    /// component to the currently hovered [`Selectable`], effectively replacing the old selection.
+    ///
+    /// If no [`Selectable`] is under the mouse, and the inner boolean is false, this is a NOOP.
+    ReplaceSelectionWithHovered(bool),
+
+    /// Add [`Selected`] to the currently hovered [`Selectable`]. This does not affect other
+    /// [`Entity`] insances that are [`Selected`], so it can be thought of as "extending" the
+    /// selection with the hovered [`Entity`].
+    ExtendSelectionWithHovered,
+
+    /// Remove [`Selected`] from the currently hovered [`Selectable`]. This does not affect another
+    /// [`Entity`]0insances, so it can be thought of as "deselecting" the one, hovered entity.
+    RemoveHoveredFromSelection,
+
+    /// Directly tracks a new [`Entity`] marking it with [`Selected`].
+    ///
+    /// NOTE: This does not perform any check that the given [`Entity`] is selectable.
+    DirectInsert(Entity),
+
+    /// Directly untracks an [`Entity`] should it have been [`Selected`], removing [`Selected`] in
+    /// the process.
+    DirectRemove(Entity),
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle_selections(
+    mut input_events: EventReader<SelectionControlEvent>,
+
+    mut egui_contexts: EguiContexts,
+
+    window: Query<&Window, With<PrimaryWindow>>,
+    camera: Query<(&Camera, &GlobalTransform), With<MainCamera>>,
+    is_selectable: Query<&Selectable>,
+
+    rapier_contex: Res<RapierContext>,
+    mut active_selection: ResMut<ActiveSelection>,
+
+    mut commands: Commands,
+) {
+    let mut hovered = || {
+        if egui_contexts.ctx_mut().wants_pointer_input() {
+            return None;
+        }
+
+        let window = window.single();
+
+        let cursor_pos = window.cursor_position()?;
+        let (camera, camera_transform) = camera.single();
+
+        let ray = camera.viewport_to_world(camera_transform, cursor_pos)?;
+
+        Some(
+            rapier_contex
+                .cast_ray(
+                    ray.origin,
+                    ray.direction,
+                    f32::MAX,
+                    true,
+                    QueryFilter::exclude_kinematic().exclude_sensors(),
+                )?
+                .0,
+        )
+    };
+
+    let drain = |active_selection: &mut ResMut<ActiveSelection>, commands: &mut Commands| {
+        active_selection.0.drain().for_each(|e| {
+            commands.entity(e).remove::<Selected>();
+        });
+    };
+
+    let extend = |entity: Entity,
+                  active_selection: &mut ResMut<ActiveSelection>,
+                  commands: &mut Commands| {
+        active_selection.0.insert(entity);
+        commands.entity(entity).insert(Selected);
+    };
+
+    let remove_individual = |entity: Entity,
+                             active_selection: &mut ResMut<ActiveSelection>,
+                             commands: &mut Commands| {
+        if active_selection.0.remove(&entity) {
+            commands.entity(entity).remove::<Selected>();
+        }
+    };
+
+    for input_event in input_events.iter() {
+        match input_event {
+            SelectionControlEvent::ClearSelection => drain(&mut active_selection, &mut commands),
+
+            SelectionControlEvent::ReplaceSelectionWithHovered(deselect_on_none) => {
+                if let Some(entity) = hovered() {
+                    if is_selectable.get(entity).is_err() {
+                        if *deselect_on_none {
+                            drain(&mut active_selection, &mut commands);
+                        }
+
+                        return;
+                    }
+
+                    drain(&mut active_selection, &mut commands);
+                    extend(entity, &mut active_selection, &mut commands);
+                } else if *deselect_on_none {
+                    drain(&mut active_selection, &mut commands);
+                }
+            }
+
+            SelectionControlEvent::ExtendSelectionWithHovered => {
+                if let Some(entity) = hovered() {
+                    if is_selectable.get(entity).is_err() {
+                        return;
+                    }
+
+                    extend(entity, &mut active_selection, &mut commands);
+                }
+            }
+
+            SelectionControlEvent::RemoveHoveredFromSelection => {
+                if let Some(entity) = hovered() {
+                    if is_selectable.get(entity).is_err() {
+                        return;
+                    }
+
+                    remove_individual(entity, &mut active_selection, &mut commands);
+                }
+            }
+
+            SelectionControlEvent::DirectInsert(entity) => {
+                extend(*entity, &mut active_selection, &mut commands);
+            }
+
+            SelectionControlEvent::DirectRemove(entity) => {
+                remove_individual(*entity, &mut active_selection, &mut commands);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a simple plugin which handles the "selection" of in-game objects with the mouse. This is primarily intended to be used with follower commands. Additionally introduces a `DebugSelectionInputPlugin` which adds basic controls to manage selections, and adds a fuchsia outline to selected objects.